### PR TITLE
[Debug] Replaced logic for detecting filesystem case sensitivity

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -42,7 +42,18 @@ class DebugClassLoader
         $this->isFinder = is_array($classLoader) && method_exists($classLoader[0], 'findFile');
 
         if (!isset(self::$caseCheck)) {
-            self::$caseCheck = false !== stripos(PHP_OS, 'win') ? (false !== stripos(PHP_OS, 'darwin') ? 2 : 1) : 0;
+            if (!isset(self::$caseCheck)) {
+                if(!file_exists(strtolower(__FILE__))) {
+                    // filesystem is case sensitive
+                    self::$caseCheck = 0;
+                } elseif(realpath(strtolower(__FILE__)) === realpath(__FILE__)) {
+                    // filesystem is not case sensitive
+                    self::$caseCheck = 1;
+                } else {
+                    // filesystem is not case sensitive AND realpath() fails to normalize case
+                    self::$caseCheck = 2;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
[Debug] Replaced logic for detecting filesystem case sensitivity

When I cloned the master branch onto a Virtualbox Vagrant OSX El Capitan host, Ubuntu Wily guest, the `Symfony\Component\Debug\Tests\DebugClassLoaderTest::testFileCaseMismatch` failed because 'Failed asserting that exception of type "\RuntimeException" is thrown'.

@WouterJ confirmed he got the same problem, and it's because Virtualbox shared folders aren't case sensitive, even when the guest is using a case sensitive filesystem. So I've replaced the logic that looked at the name of the operating system.

I ran the tests in the following environments:
- Virtualbox/Vagrant - OSX Host, Ubuntu guest
- Virtualbox/Vagrant - OSX Host, Windows guest
- OSX native
- Ubuntu native

NB - I _didn't_ run it on native Windows (because I don't have easy access to one).
